### PR TITLE
Added CanonicalEffect instance for MonadRandom in RandomFu

### DIFF
--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --

--- a/src/Polysemy/RandomFu.hs
+++ b/src/Polysemy/RandomFu.hs
@@ -115,6 +115,8 @@ absorbMonadRandom
 absorbMonadRandom = absorb @R.MonadRandom
 {-# INLINEABLE absorbMonadRandom #-}
 
+type instance  CanonicalEffect R.MonadRandom = RandomFu
+
 instance ReifiableConstraint1 (R.MonadRandom) where
   data Dict1 R.MonadRandom m = MonadRandom
     {


### PR DESCRIPTION
I forgot this before, the instance of the ```CanonicalEffect``` type-family for MonadRandom.  It's not urgent, but it ought to be in there.