### PR TITLE
Add hspec discover

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -62,6 +62,8 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    build-tools:
+    - hspec-discover  >= 2.0
     dependencies:
     - polysemy >= 0.4
     - polysemy-zoo

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: be5a00f62e6365b8c06031d6b6bba39891290626e69ab7d0a78f1861f2dd035d
+-- hash: ba5bfe9516931b18e9d5b0379d9a499b641b8f9bc03ed1fbf3c67f7ba65b1719
 
 name:           polysemy-zoo
 version:        0.2.0.0
@@ -65,6 +65,8 @@ test-suite polysemy-zoo-test
       test
   default-extensions: DataKinds DeriveFunctor FlexibleContexts GADTs LambdaCase PolyKinds RankNTypes ScopedTypeVariables StandaloneDeriving TypeApplications TypeOperators TypeFamilies UnicodeSyntax
   ghc-options: -fplugin=Polysemy.Plugin -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover >=2.0
   build-depends:
       base >=4.7 && <5
     , constraints >=0.10.1 && <0.12


### PR DESCRIPTION
TL;DR: Adds ```hspec-discover``` as a build-tool dependency in ```package.yaml``` and the corresponding new cabal file.

The test suite won't build without hspec-discover being installed.  This bit me two ways:

- The first time I tried testing the zoo, I didn't have hspec-discover installed and so the tests wouldn't build.

- haskell-ci generated travis.yml wasn't working for RandomFu until I added hspec-discover as a build-tool dependency in the test section. 